### PR TITLE
Make conda store widgets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,7 @@ docs/_build/
 # PyBuilder
 target/
 .ipynb_checkpoints/
+*.ipynb
 *.xunit.xml
 screenshots/
 node_modules/

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ git clone git@github.com:quansight/gator
 cd gator
 pip install -e .
 yarn install
-./node_modules/.bin/lerna run watch --parallel  # <-- enable automatic rebuilds
+lerna run watch --parallel  # <-- enable automatic rebuilds
 ```
 
 Elsewhere, start the jupyter server in watch mode:

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "prettier": "npx prettier --write \"**/*{.ts,.tsx,.js,.jsx,.css,.json,.md}\"",
     "prettier:check": "npx prettier --list-different \"**/*{.ts,.tsx,.js,.jsx,.css,.json,.md}\"",
     "publish": "yarn run clean && yarn run build && lerna publish",
-    "test": "lerna run test"
+    "test": "lerna run test",
+    "watch": "lerna run watch --parallel"
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^4.8.1",

--- a/packages/common/src/CondaEnvWidget.tsx
+++ b/packages/common/src/CondaEnvWidget.tsx
@@ -8,7 +8,7 @@ import { IEnvironmentManager } from './tokens';
 /**
  * Widget size interface
  */
-interface ISize {
+export interface ISize {
   /**
    * Widget heigth
    */
@@ -54,9 +54,9 @@ export class CondaEnvWidget extends ReactWidget {
   /**
    * Conda environment Manager
    */
-  private _envModel: IEnvironmentManager;
+  protected _envModel: IEnvironmentManager;
   /**
    * Signal triggering a React rendering if widget is resized
    */
-  private _resizeSignal = new Signal<CondaEnvWidget, ISize>(this);
+  protected _resizeSignal = new Signal<CondaEnvWidget, ISize>(this);
 }

--- a/packages/common/src/CondaStoreEnvWidget.tsx
+++ b/packages/common/src/CondaStoreEnvWidget.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { Signal } from '@lumino/signaling';
+import { UseSignal } from '@jupyterlab/apputils';
+import { CondaEnvWidget, ISize } from './CondaEnvWidget'
+import { NbCondaStore } from './components/NbCondaStore';
+import { CondaStoreEnvironments } from './services';
+
+export class CondaStoreEnvWidget extends CondaEnvWidget {
+    render(): JSX.Element {
+        return (
+            <UseSignal
+                signal={this._resizeSignal}
+                initialArgs={{ height: 0, width: 0 }}
+            >
+                {(_, size): JSX.Element => (
+                    <NbCondaStore
+                        height={size.height}
+                        width={size.width}
+                        model={this._envModel}
+                    />
+                )}
+            </UseSignal>
+        );
+    }
+
+    // Possibly remove; we aren't using it inside NbCondaStore
+    protected _envModel: CondaStoreEnvironments
+    protected _resizeSignal = new Signal<CondaStoreEnvWidget, ISize>(this);
+}

--- a/packages/common/src/components/CondaEnvList.tsx
+++ b/packages/common/src/components/CondaEnvList.tsx
@@ -4,7 +4,6 @@ import { CONDA_ENVIRONMENT_PANEL_ID } from '../constants';
 import { Conda } from '../tokens';
 import { CondaEnvItem } from './CondaEnvItem';
 import { CondaEnvToolBar, ENVIRONMENT_TOOLBAR_HEIGHT } from './CondaEnvToolBar';
-import { CondaStore } from '..';
 
 export const ENVIRONMENT_PANEL_WIDTH = 250;
 
@@ -24,12 +23,6 @@ export interface IEnvListProps {
    * Environment list
    */
   environments: Array<Conda.IEnvironment>;
-
-  /**
-   * Conda Store Environment list
-   */
-  conda_store_environments: Array<CondaStore.IEnvironment>;
-  
   /**
    * Currently selected environment
    */
@@ -72,26 +65,20 @@ export const CondaEnvList: React.FunctionComponent<IEnvListProps> = (
 ) => {
   let isDefault = false;
   const listItems = props.environments.map((env, idx) => {
-    const conda_store_idx = Math.min(props.conda_store_environments.length -1, idx);
-    const conda_store_env = props.conda_store_environments[conda_store_idx];
     const selected = env.name === props.selected;
     if (selected) {
       // Forbid clone and removing the environment named "base" (base conda environment)
       // and the default one (i.e. the one containing JupyterLab)
       isDefault = env.is_default || env.name === 'base';
     }
-    if(idx <= props.conda_store_environments.length -1){
-      return (
-        <CondaEnvItem
-          name={conda_store_env.name}
-          key={env.name}
-          selected={props.selected ? env.name === props.selected : false}
-          onClick={props.onSelectedChange}
-        />
-      );
-    }else{
-      return null;
-    }
+    return (
+      <CondaEnvItem
+        name={env.name}
+        key={env.name}
+        selected={props.selected ? env.name === props.selected : false}
+        onClick={props.onSelectedChange}
+      />
+    );
   });
 
   return (

--- a/packages/common/src/components/CondaPkgPanel.tsx
+++ b/packages/common/src/components/CondaPkgPanel.tsx
@@ -13,7 +13,7 @@ import {
 import { PkgGraphWidget } from './PkgGraph';
 
 // Minimal panel width to show package description
-const PANEL_SMALL_WIDTH = 500;
+export const PANEL_SMALL_WIDTH = 500;
 
 /**
  * Package panel property
@@ -524,7 +524,7 @@ export class CondaPkgPanel extends React.Component<
   private _currentEnvironment = '';
 }
 
-namespace Style {
+export namespace Style {
   export const Panel = style({
     flexGrow: 1,
     borderLeft: '1px solid var(--jp-border-color2)'

--- a/packages/common/src/components/CondaStorePkgPanel.tsx
+++ b/packages/common/src/components/CondaStorePkgPanel.tsx
@@ -1,0 +1,123 @@
+import React from 'react'
+import {
+  CondaPkgToolBar,
+  PACKAGE_TOOLBAR_HEIGHT,
+  PkgFilters
+} from './CondaPkgToolBar';
+import {IPkgPanelProps, IPkgPanelState, Style, PANEL_SMALL_WIDTH} from './CondaPkgPanel'
+import { Conda } from '../tokens';
+import { CondaPkgList } from './CondaPkgList';
+
+export class CondaStorePkgPanel extends React.Component<IPkgPanelProps, IPkgPanelState> {
+    constructor(props: IPkgPanelProps) {
+        super(props)
+        this.state = {
+            isLoading: false,
+            isApplyingChanges: false,
+            hasDescription: false,
+            hasUpdate: false,
+            packages: [],
+            selected: [],
+            searchTerm: '',
+            activeFilter: PkgFilters.All
+        }
+
+        this.handleCategoryChanged = this.handleCategoryChanged.bind(this);
+        this.handleClick = this.handleClick.bind(this);
+        this.handleVersionSelection = this.handleVersionSelection.bind(this);
+        this.handleSearch = this.handleSearch.bind(this);
+        this.handleUpdateAll = this.handleUpdateAll.bind(this);
+        this.handleApply = this.handleApply.bind(this);
+        this.handleCancel = this.handleCancel.bind(this);
+        this.handleRefreshPackages = this.handleRefreshPackages.bind(this);
+    }
+
+    handleCategoryChanged(): void {
+        return
+    }
+    handleClick(): void {
+        return
+    }
+    handleVersionSelection(): void {
+        return
+    }
+    handleSearch(): void {
+        return
+    }
+    handleUpdateAll(): void {
+        return
+    }
+    handleApply(): void {
+        return
+    }
+    handleCancel(): void {
+        return
+    }
+    handleRefreshPackages(): void {
+        return
+    }
+    handleDependenciesGraph(): void {
+        return
+    }
+
+    render(): JSX.Element {
+        let filteredPkgs: Conda.IPackage[] = [];
+        if (this.state.activeFilter === PkgFilters.All) {
+            filteredPkgs = this.state.packages;
+        } else if (this.state.activeFilter === PkgFilters.Installed) {
+            filteredPkgs = this.state.packages.filter(pkg => pkg.version_installed);
+        } else if (this.state.activeFilter === PkgFilters.Available) {
+            filteredPkgs = this.state.packages.filter(pkg => !pkg.version_installed);
+        } else if (this.state.activeFilter === PkgFilters.Updatable) {
+            filteredPkgs = this.state.packages.filter(pkg => pkg.updatable);
+        } else if (this.state.activeFilter === PkgFilters.Selected) {
+            filteredPkgs = this.state.packages.filter(
+                pkg => this.state.selected.indexOf(pkg) >= 0
+            );
+        }
+
+        let searchPkgs: Conda.IPackage[] = [];
+        if (this.state.searchTerm === null) {
+            searchPkgs = filteredPkgs;
+        } else {
+            searchPkgs = filteredPkgs.filter(pkg => {
+                const lowerSearch = this.state.searchTerm.toLowerCase();
+                return (
+                    pkg.name.indexOf(this.state.searchTerm) >= 0 ||
+                    (this.state.hasDescription &&
+                        (pkg.summary.indexOf(this.state.searchTerm) >= 0 ||
+                            pkg.keywords.indexOf(lowerSearch) >= 0 ||
+                            pkg.tags.indexOf(lowerSearch) >= 0))
+                );
+            });
+        }
+
+        return (
+            <div className={Style.Panel}>
+                <CondaPkgToolBar
+                    isPending={this.state.isLoading}
+                    category={this.state.activeFilter}
+                    hasSelection={this.state.selected.length > 0}
+                    hasUpdate={this.state.hasUpdate}
+                    searchTerm={this.state.searchTerm}
+                    onCategoryChanged={this.handleCategoryChanged}
+                    onSearch={this.handleSearch}
+                    onUpdateAll={this.handleUpdateAll}
+                    onApply={this.handleApply}
+                    onCancel={this.handleCancel}
+                    onRefreshPackages={this.handleRefreshPackages}
+                />
+                <CondaPkgList
+                    height={this.props.height - PACKAGE_TOOLBAR_HEIGHT}
+                    hasDescription={
+                        this.state.hasDescription && this.props.width > PANEL_SMALL_WIDTH
+                    }
+                    packages={searchPkgs}
+                    onPkgClick={this.handleClick}
+                    onPkgChange={this.handleVersionSelection}
+                    onPkgGraph={this.handleDependenciesGraph}
+                />
+            </div>
+        );
+    }
+}

--- a/packages/common/src/components/NbConda.tsx
+++ b/packages/common/src/components/NbConda.tsx
@@ -3,7 +3,6 @@ import { Widget } from '@lumino/widgets';
 import { INotification } from 'jupyterlab_toastify';
 import * as React from 'react';
 import { style } from 'typestyle';
-import { CondaStore } from '..';
 import { Conda, IEnvironmentManager } from '../tokens';
 import { CondaEnvList, ENVIRONMENT_PANEL_WIDTH } from './CondaEnvList';
 import { CondaPkgPanel } from './CondaPkgPanel';
@@ -35,10 +34,6 @@ export interface ICondaEnvState {
    */
   environments: Array<Conda.IEnvironment>;
   /**
-   * Conda Store Environment list
-   */
-  conda_store_environments: Array<CondaStore.IEnvironment>;
-  /**
    * Active environment
    */
   currentEnvironment?: string;
@@ -59,7 +54,6 @@ export class NbConda extends React.Component<ICondaEnvProps, ICondaEnvState> {
 
     this.state = {
       environments: [],
-      conda_store_environments: [],
       currentEnvironment: undefined,
       isLoading: false
     };
@@ -367,7 +361,6 @@ export class NbConda extends React.Component<ICondaEnvProps, ICondaEnvState> {
       try {
         const newState: Partial<ICondaEnvState> = {
           environments: await this.props.model.environments,
-          conda_store_environments: await CondaStore.fetchEnvironments()
         };
         if (this.state.currentEnvironment === undefined) {
           newState.environments.forEach(env => {
@@ -385,6 +378,7 @@ export class NbConda extends React.Component<ICondaEnvProps, ICondaEnvState> {
         if (error !== 'cancelled') {
           console.error(error);
           INotification.error(error.message);
+          this.setState({isLoading: false})
         }
       }
     }
@@ -401,7 +395,6 @@ export class NbConda extends React.Component<ICondaEnvProps, ICondaEnvState> {
           height={this.props.height}
           isPending={this.state.isLoading}
           environments={this.state.environments}
-          conda_store_environments = {this.state.conda_store_environments}
           selected={this.state.currentEnvironment}
           onSelectedChange={this.handleEnvironmentChange}
           onCreate={this.handleCreateEnvironment}
@@ -423,7 +416,7 @@ export class NbConda extends React.Component<ICondaEnvProps, ICondaEnvState> {
   }
 }
 
-namespace Style {
+export namespace Style {
   export const Panel = style({
     width: '100%',
     display: 'flex',

--- a/packages/common/src/components/NbCondaStore.tsx
+++ b/packages/common/src/components/NbCondaStore.tsx
@@ -1,0 +1,113 @@
+import React from 'react'
+// import { Dialog, showDialog } from '@jupyterlab/apputils';
+// import { Widget } from '@lumino/widgets';
+import { INotification } from 'jupyterlab_toastify'
+import { CondaStore } from '..'
+import { NbConda, Style } from './NbConda'
+import { CondaPkgPanel } from './CondaPkgPanel';
+import { CondaEnvList, ENVIRONMENT_PANEL_WIDTH } from './CondaEnvList';
+
+// function createNewEnvironmentDialog(environmentTypes: Array<string>): {
+//     body: HTMLElement,
+//     typeInput: HTMLSelectElement,
+//     nameInput: HTMLInputElement,
+// } {
+//     const body = document.createElement('div');
+//     const nameLabel = document.createElement('label');
+//     nameLabel.textContent = 'Name : ';
+//     const nameInput = document.createElement('input');
+//     body.appendChild(nameLabel);
+//     body.appendChild(nameInput);
+
+//     const typeLabel = document.createElement('label');
+//     typeLabel.textContent = 'Type : ';
+//     const typeInput = document.createElement('select');
+//     for (const type of environmentTypes) {
+//         const option = document.createElement('option');
+//         option.setAttribute('value', type);
+//         option.innerText = type;
+//         typeInput.appendChild(option);
+//     }
+//     body.appendChild(typeLabel);
+//     body.appendChild(typeInput);
+//     return {body, typeInput, nameInput}
+// }
+
+export class NbCondaStore extends NbConda {
+    async loadEnvironments(): Promise<void> {
+        if (!this.state.isLoading) {
+            this.setState({isLoading: true})
+            try {
+                const environments = await CondaStore.fetchEnvironments()
+                this.setState({...this.state, isLoading: false, environments})
+            } catch (error) {
+                if (error !== 'cancelled') {
+                    console.error(error)
+                    INotification.error(error.message)
+                    this.setState({isLoading: false})
+                }
+            }
+        }
+    }
+
+    async handleEnvironmentChange(name: string): Promise<void> {
+        this.setState({
+            currentEnvironment: name,
+            channels: await CondaStore.getChannels()
+        })
+    }
+
+    async handleCreateEnvironment(): Promise<void> {
+
+        // const {body, typeInput, nameInput} = createNewEnvironmentDialog(this.props.model.environmentTypes)
+        // const response = await showDialog({
+        //     title: 'New Environment',
+        //     body: new Widget({ node: body }),
+        //     buttons: [Dialog.cancelButton(), Dialog.okButton()]
+        // });
+        return
+    }
+
+    async handleCloneEnvironment(): Promise<void> {
+        return
+    }
+    async handleImportEnvironment(): Promise<void> {
+        return
+    }
+    async handleExportEnvironment(): Promise<void> {
+        return
+    }
+    async handleRefreshEnvironment(): Promise<void> {
+        await this.loadEnvironments()
+    }
+    async handleRemoveEnvironment(): Promise<void> {
+        return
+    }
+
+    render(): JSX.Element {
+        return (
+            <div className={Style.Panel}>
+                <CondaEnvList
+                    height={this.props.height}
+                    isPending={this.state.isLoading}
+                    environments={this.state.environments}
+                    selected={this.state.currentEnvironment}
+                    onSelectedChange={this.handleEnvironmentChange}
+                    onCreate={this.handleCreateEnvironment}
+                    onClone={this.handleCloneEnvironment}
+                    onImport={this.handleImportEnvironment}
+                    onExport={this.handleExportEnvironment}
+                    onRefresh={this.handleRefreshEnvironment}
+                    onRemove={this.handleRemoveEnvironment}
+                />
+                <CondaPkgPanel
+                    height={this.props.height}
+                    width={this.props.width - ENVIRONMENT_PANEL_WIDTH}
+                    packageManager={this.props.model.getPackageManager(
+                        this.state.currentEnvironment
+                    )}
+                />
+            </div>
+        )
+    }
+}

--- a/packages/common/src/condaStore.ts
+++ b/packages/common/src/condaStore.ts
@@ -1,8 +1,12 @@
+import {Conda} from '../src/tokens'
+
+const baseUrl = 'http://localhost:5000/api/v1'
+
 export namespace CondaStore {
     /**
      * Description of the REST API response for each environment
      */
-    export interface IEnvironment {
+    export interface IEnvironment extends Conda.IEnvironment {
         build_id: number,
         id: number,
         name: string,
@@ -12,29 +16,46 @@ export namespace CondaStore {
         }
     }
 
-    export async function fetchEnvironments(): Promise<Array<IEnvironment>> {
-        const result = await fetch('http://localhost:5000/api/v1/environment/')
-        if (result.ok) {
-            return await result.json()
-        } else {
-            return []
-        }
-    }
-
-    export async function fetchEnvironmentPackages(envNamespace: string, envName: string): Promise<Array<{
+    export interface IPackage {
         channel_id: number,
         id: number,
         license: string,
         name: string,
         sha256: string,
         version: string,
-    }>> {
-        const result = await fetch(`http://localhost:5000/api/v1/environment/${envNamespace}/${envName}/`)
-        if (result.ok) {
-            const {packages} = await result.json()
+    }
+
+    export async function fetchEnvironments(): Promise<Array<IEnvironment>> {
+        const response = await fetch(`${baseUrl}/environment/`)
+        if (response.ok) {
+            return await response.json()
+        } else {
+            return []
+        }
+    }
+
+    export async function fetchEnvironmentPackages(envNamespace: string, envName: string): Promise<Array<IPackage>> {
+        const response = await fetch(`${baseUrl}/environment/${envNamespace}/${envName}/`)
+        if (response.ok) {
+            const {packages} = await response.json()
             return packages
         } else {
             return []
         }
+    }
+
+    export async function getChannels(): Promise<Conda.IChannels> {
+        const response = await fetch(`${baseUrl}/channel/`)
+        if (response.ok) {
+            const channels = await response.json()
+
+            // Reformat the channels into the form expected for NbCondaStore
+            const data: Conda.IChannels = {}
+            channels.forEach(({name}: {name: string}) => {
+                data[name] = [name]
+            });
+            return data
+        }
+        return {}
     }
 }

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -1,6 +1,7 @@
 export { CondaEnvWidget } from './CondaEnvWidget';
+export { CondaStoreEnvWidget } from './CondaStoreEnvWidget';
 export * from './constants';
 export { condaIcon } from './icon';
-export { CondaEnvironments } from './services';
+export { CondaEnvironments, CondaStoreEnvironments } from './services';
 export { Conda, IEnvironmentManager } from './tokens';
 export { CondaStore } from './condaStore';

--- a/packages/common/src/services.ts
+++ b/packages/common/src/services.ts
@@ -418,6 +418,8 @@ export class CondaEnvironments implements IEnvironmentManager {
   private _whitelist = false;
 }
 
+export class CondaStoreEnvironments extends CondaEnvironments {}
+
 export class CondaPackage implements Conda.IPackageManager {
   /**
    * Conda environment of interest

--- a/packages/common/src/tokens.ts
+++ b/packages/common/src/tokens.ts
@@ -82,11 +82,14 @@ export namespace Conda {
   /**
    * Description of the REST API response for each environment
    */
-  export interface IEnvironment {
+  export interface IEnvironmentBase {
     /**
      * Environment name
      */
     name: string;
+  }
+
+  export interface IEnvironment extends IEnvironmentBase {
     /**
      * Environment path
      */

--- a/packages/labextension/src/index.ts
+++ b/packages/labextension/src/index.ts
@@ -12,7 +12,9 @@ import { IMainMenu } from '@jupyterlab/mainmenu';
 import { ISettingRegistry } from '@jupyterlab/settingregistry';
 import {
   CondaEnvironments,
+  CondaStoreEnvironments,
   CondaEnvWidget,
+  CondaStoreEnvWidget,
   condaIcon,
   CONDA_WIDGET_CLASS,
   IEnvironmentManager
@@ -43,16 +45,16 @@ async function activateCondaStoreEnv(
   const command = 'jupyter_conda_store:open-ui';
 
   const settings = await settingsRegistry?.load(CONDAENVID);
-  const model = new CondaEnvironments(settings);
+  const model = new CondaStoreEnvironments(settings);
 
   // Request listing available package as quickly as possible
   Private.loadPackages(model);
 
   // Track and restore the widget state
-  const tracker = new WidgetTracker<MainAreaWidget<CondaEnvWidget>>({
+  const tracker = new WidgetTracker<MainAreaWidget<CondaStoreEnvWidget>>({
     namespace: pluginNamespace
   });
-  let condaWidget: MainAreaWidget<CondaEnvWidget>;
+  let condaWidget: MainAreaWidget<CondaStoreEnvWidget>;
 
   commands.addCommand(command, {
     label: 'Conda Store Packages Manager',
@@ -91,7 +93,7 @@ async function activateCondaStoreEnv(
 
       if (!condaWidget || condaWidget.isDisposed) {
         condaWidget = new MainAreaWidget({
-          content: new CondaEnvWidget(model)
+          content: new CondaStoreEnvWidget(model)
         });
         condaWidget.addClass(CONDA_WIDGET_CLASS);
         condaWidget.id = pluginNamespace;


### PR DESCRIPTION
This PR splits the conda-store functionality introduced by @jess-x into a separate code path, so as to avoid breaking existing functionality.

## Changes
* Minor correction to dev environment instructions in `README.md`
* Added `watch` script in `package.json`. Watching for frontend changes can now be done by calling `yarn watch`.
* Created a new `CondaStoreEnvWidget` which extends the existing `CondaEnvWidget`. To make this possible, I had to change a few `CondaEnvWidget` properties from `private` to `protected` so I had access to them in the subclass. `CondaStoreEnvWidget` looks exactly the same as its parent except that it renders a new `NbCondaStore` react component rather than a `NbConda` component.
* Removed any reference to conda-store from `CondaEnvList`. This component will handle conda-store environments exactly the same as conda environments for now (after all, conda-store environments _are_ conda environments)
* Fixed issue where `NbConda` would stay in a loading state forever if the request to the backend failed
* Removed all mention of conda-store from `NbConda`; this has been moved to a separate subclass of `NbConda` called `NbCondaStore`. For now, only the `NbCondaStore.loadEnvironments()` function is reimplemented; other functionality will be added in a subsequent PR
* I split the `IEnvironment` interface into a base class and two subclasses: one for regular conda use, and one for conda-store. This is because `CondaStore.IEnvironment` is used for typing the responses from the conda-store server; this way, we can use either kind of `IEnvironment` for populating the list of environments in a `CondaEnvList` component.