### PR TITLE
Put conda-store URL into settingsRegistry.

### DIFF
--- a/packages/common/src/CondaStoreEnvWidget.tsx
+++ b/packages/common/src/CondaStoreEnvWidget.tsx
@@ -1,10 +1,26 @@
 import React from 'react';
-import { Signal } from '@lumino/signaling';
-import { UseSignal } from '@jupyterlab/apputils';
-import { CondaEnvWidget, ISize } from './CondaEnvWidget'
-import { NbCondaStore } from './components/NbCondaStore';
+import { ReactWidget, UseSignal } from '@jupyterlab/apputils'
+import { Widget } from '@lumino/widgets';
+import { Signal } from '@lumino/signaling'
+import { NbCondaStore } from './components/NbCondaStore'
 
-export class CondaStoreEnvWidget extends CondaEnvWidget {
+interface ISize {
+    height: number
+    width: number
+}
+
+export class CondaStoreEnvWidget extends ReactWidget {
+    constructor(condaStoreUrl: string) {
+        super()
+        this.condaStoreUrl = condaStoreUrl
+    }
+
+    protected onResize(msg: Widget.ResizeMessage): void {
+        const { height, width } = msg;
+        this._resizeSignal.emit({ height, width });
+        super.onResize(msg);
+    }
+
     render(): JSX.Element {
         return (
             <UseSignal
@@ -15,6 +31,7 @@ export class CondaStoreEnvWidget extends CondaEnvWidget {
                     <NbCondaStore
                         height={size.height}
                         width={size.width}
+                        condaStoreUrl={this.condaStoreUrl}
                     />
                 )}
             </UseSignal>
@@ -23,4 +40,5 @@ export class CondaStoreEnvWidget extends CondaEnvWidget {
 
     // Possibly remove; we aren't using it inside NbCondaStore
     protected _resizeSignal = new Signal<CondaStoreEnvWidget, ISize>(this);
+    protected condaStoreUrl: string
 }

--- a/packages/common/src/components/CondaStorePkgPanel.tsx
+++ b/packages/common/src/components/CondaStorePkgPanel.tsx
@@ -17,6 +17,7 @@ interface ICondaStorePkgPanelProps {
     width: number
     namespace: string
     environment: string
+    condaStoreUrl: string
 }
 
 export interface ICondaStorePackageMapEntry {
@@ -29,6 +30,7 @@ export function CondaStorePkgPanel({
     width,
     environment,
     namespace,
+    condaStoreUrl,
 }: ICondaStorePkgPanelProps): JSX.Element {
     const [searchTerm, setSearchTerm] = useState('')
     const [activeFilter, setActiveFilter] = useState(PkgFilters.All)
@@ -111,6 +113,7 @@ export function CondaStorePkgPanel({
 
     const getInstalledPackages = useCallback(async (): Promise<Array<ICondaStorePackage>> => {
         const {count, data, page, size} = await fetchEnvironmentPackages(
+            condaStoreUrl,
             namespace,
             environment,
             installedPackagesPage,
@@ -119,15 +122,18 @@ export function CondaStorePkgPanel({
         setInstalledPackagesPage(installedPackagesPage+1)
         setHasMoreInstalledPackages(count > page*size)
         return data
-    }, [environment, namespace, installedPackagesPage])
+    }, [environment, namespace, installedPackagesPage, condaStoreUrl])
 
     const getAvailablePackages = useCallback(async (): Promise<Array<ICondaStorePackage>> => {
-        const {count, data, page, size} = await fetchPackages(packagesPage)
+        const {count, data, page, size} = await fetchPackages(
+            condaStoreUrl,
+            packagesPage
+        )
         setNPackages(count)
         setPackagesPage(packagesPage+1)
         setHasMoreData(count > page*size)
         return data
-    }, [packagesPage])
+    }, [packagesPage, condaStoreUrl])
 
     const loadPackages = useCallback(async () => {
         if (hasMoreData && !isLoading) {

--- a/packages/common/src/components/NbCondaStore.tsx
+++ b/packages/common/src/components/NbCondaStore.tsx
@@ -8,11 +8,13 @@ import { CondaStoreEnvList, ENVIRONMENT_PANEL_WIDTH } from './CondaStoreEnvList'
 export interface INbCondaStoreProps {
     height: number
     width: number
+    condaStoreUrl: string
 }
 
 export function NbCondaStore({
     height,
     width,
+    condaStoreUrl,
 }: INbCondaStoreProps): JSX.Element {
 
     const [isLoading, setIsLoading] = useState(false)
@@ -30,13 +32,16 @@ export function NbCondaStore({
     const loadEnvironments = useCallback(async () => {
         if (hasMoreData && !isLoading) {
             setIsLoading(true)
-            const {count, data, page, size} = await fetchEnvironments(environmentPage)
+            const {count, data, page, size} = await fetchEnvironments(
+                condaStoreUrl,
+                environmentPage,
+            )
             setEnvironments([...environments, ...data])
             setEnvironmentPage(environmentPage+1)
             setHasMoreData(count > page*size)
             setIsLoading(false)
         }
-    }, [hasMoreData, isLoading, environments, environmentPage])
+    }, [hasMoreData, isLoading, environments, environmentPage, condaStoreUrl])
 
     async function environmentChange(environment: string, namespace: string): Promise<void> {
         setActiveEnvironment(environment)
@@ -102,6 +107,7 @@ export function NbCondaStore({
                 width={width - ENVIRONMENT_PANEL_WIDTH}
                 namespace={activeNamespace}
                 environment={activeEnvironment}
+                condaStoreUrl={condaStoreUrl}
             />
         </div>
     )

--- a/packages/common/src/condaStore.ts
+++ b/packages/common/src/condaStore.ts
@@ -1,5 +1,3 @@
-const baseUrl = 'http://localhost:5000/api/v1'
-
 export interface ICondaStoreEnvironment {
     name: string
     build_id: number
@@ -41,6 +39,19 @@ interface IPaginatedResult<T> {
     status?: string
 }
 
+/**
+ * Construct the base URL for conda-store requests.
+ *
+ * @param {string} condaStoreUrl URL of the conda-store server
+ * @param {string} [apiRoot] - Root of the conda-store API
+ * @return {string} Base URL for requests to the conda-store server
+ */
+function getBaseUrl(
+    condaStoreUrl = 'http://localhost:5000',
+    apiRoot = 'api/v1',
+): string {
+    return `${condaStoreUrl}/${apiRoot}`
+}
 
 /**
  * Fetch all conda-store environments.
@@ -48,7 +59,8 @@ interface IPaginatedResult<T> {
  * @async
  * @return {Promise<IPaginatedResult<ICondaStoreEnvironment>>} All environments visible to conda-store.
  */
-export async function fetchEnvironments(page = 1, size = 100): Promise<IPaginatedResult<ICondaStoreEnvironment>> {
+export async function fetchEnvironments(condaStoreUrl: string, page = 1, size = 100): Promise<IPaginatedResult<ICondaStoreEnvironment>> {
+    const baseUrl = getBaseUrl(condaStoreUrl)
     const response = await fetch(`${baseUrl}/environment/?page=${page}&size=${size}`)
     if (response.ok) {
         return await response.json()
@@ -61,10 +73,12 @@ export async function fetchEnvironments(page = 1, size = 100): Promise<IPaginate
  * Search all packages (both installed and not installed) for a package.
  *
  * @async
+ * @param {string} condaStoreUrl URL of the conda-store server
  * @param {string} term - Search term; both name and descriptions are searched
  * @return {Promise<Array<ICondaStorePackage>>} Packages matching the search term.
  */
-export async function searchPackages(term: string): Promise<Array<ICondaStorePackage>> {
+export async function searchPackages(condaStoreUrl: string, term: string): Promise<Array<ICondaStorePackage>> {
+    const baseUrl = getBaseUrl(condaStoreUrl)
     const response = await fetch(`${baseUrl}/package/?search=${term}`)
     if (response.ok) {
         return await response.json()
@@ -80,7 +94,8 @@ export async function searchPackages(term: string): Promise<Array<ICondaStorePac
  * @async
  * @return {Promise<IPaginatedResult<ICondaStorePackage>>} List of available packages
  */
-export async function fetchPackages(page = 1, size = 100): Promise<IPaginatedResult<ICondaStorePackage>> {
+export async function fetchPackages(condaStoreUrl: string, page = 1, size = 100): Promise<IPaginatedResult<ICondaStorePackage>> {
+    const baseUrl = getBaseUrl(condaStoreUrl)
     const response = await fetch(`${baseUrl}/package/?page=${page}&size=${size}&distinct_on=name&distinct_on=version`)
     if (response.ok) {
         return await response.json()
@@ -93,12 +108,14 @@ export async function fetchPackages(page = 1, size = 100): Promise<IPaginatedRes
  * List the installed packages for the given environment and namespace.
  *
  * @async
+ * @param {string} condaStoreUrl URL of the conda-store server
  * @param {string} namespace - Name of the namespace to be searched
  * @param {string} environment - Name of the environment to be searched
  * @return {Promise<IPaginatedResult<ICondaStorePackage>>} List of packages in the given namespace/environment
  * combination
  */
 export async function fetchEnvironmentPackages(
+    condaStoreUrl: string,
     namespace: string,
     environment: string,
     page = 1,
@@ -111,6 +128,7 @@ export async function fetchEnvironmentPackages(
         return {}
     }
 
+    const baseUrl = getBaseUrl(condaStoreUrl)
     let response = await fetch(`${baseUrl}/environment/${namespace}/${environment}/`)
 
     if (response.ok) {
@@ -126,8 +144,10 @@ export async function fetchEnvironmentPackages(
 }
 
 export async function fetchBuildPackages(
+    condaStoreUrl: string,
     build_id: number
 ): Promise<IPaginatedResult<ICondaStorePackage>> {
+    const baseUrl = getBaseUrl(condaStoreUrl)
     const response = await fetch(`${baseUrl}/build/${build_id}/`)
     if (response.ok) {
         return await response.json()
@@ -139,10 +159,12 @@ export async function fetchBuildPackages(
  * Fetch the channels. Channels are remote repositories containing conda packages.
  *
  * @async
+ * @param {string} condaStoreUrl URL of the conda-store server
  * @return {Promise<Array<ICondaStoreChannel>>} List of all possible channels from which packages
  * may be downloaded..
  */
-export async function fetchChannels(): Promise<Array<ICondaStoreChannel>> {
+export async function fetchChannels(condaStoreUrl: string): Promise<Array<ICondaStoreChannel>> {
+    const baseUrl = getBaseUrl(condaStoreUrl)
     const response = await fetch(`${baseUrl}/channel/`)
     if (response.ok) {
         return await response.json()

--- a/packages/labextension/schema/plugin.json
+++ b/packages/labextension/schema/plugin.json
@@ -45,6 +45,12 @@
       "title": "Only kernel whitelist",
       "description": "Show only environment corresponding to whitelisted kernels",
       "default": false
+    },
+    "condaStoreUrl": {
+        "type": "string",
+        "title": "Conda-Store URL",
+        "description": "URL of the conda-store server",
+        "default": "http://localhost:5000"
     }
   },
   "additionalProperties": false,

--- a/packages/labextension/src/index.ts
+++ b/packages/labextension/src/index.ts
@@ -33,10 +33,14 @@ const TOUR_TIMEOUT = 5 * TOUR_DELAY + 1;
 
 async function activateCondaStoreEnv(
   app: JupyterFrontEnd,
+  settingsRegistry: ISettingRegistry | null,
   palette: ICommandPalette | null,
   menu: IMainMenu | null,
   restorer: ILayoutRestorer | null
 ): Promise<void> {
+  const settings = await settingsRegistry?.load(CONDAENVID);
+  const condaStoreUrl = settings.get('condaStoreUrl').composite as string
+
   let tour: any;
   const { commands, shell } = app;
   const pluginNamespace = 'conda-store-env';
@@ -85,7 +89,7 @@ async function activateCondaStoreEnv(
 
       if (!condaWidget || condaWidget.isDisposed) {
         condaWidget = new MainAreaWidget({
-          content: new CondaStoreEnvWidget()
+          content: new CondaStoreEnvWidget(condaStoreUrl)
         });
         condaWidget.addClass(CONDA_WIDGET_CLASS);
         condaWidget.id = pluginNamespace;
@@ -279,7 +283,7 @@ const condaManager: JupyterFrontEndPlugin<IEnvironmentManager> = {
   id: CONDASTOREENVID,
   autoStart: true,
   activate: activateCondaStoreEnv,
-  optional: [ICommandPalette, IMainMenu, ILayoutRestorer],
+  optional: [ISettingRegistry, ICommandPalette, IMainMenu, ILayoutRestorer],
   provides: IEnvironmentManager
 };
 


### PR DESCRIPTION
This PR allows for the conda-store server URL to be modified through the settings registry, closing https://github.com/Quansight/conda-store/issues/146.

## Changes
* Put conda-store URL into the JupyterLab settingsRegistry as `condaStoreUrl`. By default, this setting has a value of `http://localhost:5000`

## Testing
The default conda store URL can be changed by going to the settings at `Settings -> Advanced Settings Editor -> Conda`. This will show the default value of the gator settings. On the right hand panel you can enter a different server for conda-store.

## Related
https://github.com/Quansight/conda-store/issues/146