### PR TITLE
List installed conda store packages

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -3,14 +3,17 @@ module.exports = {
     'eslint:recommended',
     'plugin:@typescript-eslint/eslint-recommended',
     'plugin:@typescript-eslint/recommended',
-    'plugin:prettier/recommended',
+    // 'plugin:prettier/recommended',
     'plugin:react/recommended'
   ],
   parser: '@typescript-eslint/parser',
   parserOptions: {
     project: 'tsconfig.json'
   },
-  plugins: ['@typescript-eslint'],
+  plugins: [
+    '@typescript-eslint',
+    'react-hooks'
+  ],
   rules: {
     '@typescript-eslint/naming-convention': [
       'error',
@@ -34,7 +37,9 @@ module.exports = {
     ],
     curly: ['error', 'all'],
     eqeqeq: 'error',
-    'prefer-arrow-callback': 'error'
+    'prefer-arrow-callback': 'error',
+    'react-hooks/rules-of-hooks': 'error',
+    'react-hooks/exhaustive-deps': 'warn'
   },
   settings: {
     react: {

--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,7 @@ docs/_build/
 # PyBuilder
 target/
 .ipynb_checkpoints/
+*.ipynb
 *.xunit.xml
 screenshots/
 node_modules/

--- a/README.md
+++ b/README.md
@@ -91,17 +91,32 @@ Open JupyterLab: [![Binder](https://mybinder.org/badge_logo.svg)](https://mybind
 
 ## Development
 
+First, set up the environment:
+
 ```shell
-mamba create -c conda-forge -y -n gator python jupyterlab=3
+mamba create -c conda-forge -y -n gator python jupyterlab
 mamba install -c conda-forge -y -n gator --file requirements_dev.txt
 conda activate gator
-pip install -e .
-jupyter server extension enable mamba_gator --sys-prefix
-
-yarn install
-yarn run build:dev
-jupyter labextension link packages/common/ packages/labextension/
 ```
+
+Clone the repo, install it with `pip`, and then watch for changes to the
+javascript:
+
+```bash
+git clone git@github.com:quansight/gator
+cd gator
+pip install -e .
+yarn install
+./node_modules/.bin/lerna run watch --parallel  # <-- enable automatic rebuilds
+```
+
+Elsewhere, start the jupyter server in watch mode:
+
+```bash
+jupyter lab --watch
+```
+
+Now you're good to go!
 
 ## Acknowledgements
 
@@ -143,7 +158,7 @@ sense to move the project in the `mamba-org` organization.
 ### 5.0.0
 
 - Features
-  - Update to JupyterLab 3 and the new Jupyter Server  
+  - Update to JupyterLab 3 and the new Jupyter Server
   You don't need to install anything more than the pip or conda package.
   - Drop support for the classical notebook.
 

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ git clone git@github.com:quansight/gator
 cd gator
 pip install -e .
 yarn install
-./node_modules/.bin/lerna run watch --parallel  # <-- enable automatic rebuilds
+lerna run watch --parallel  # <-- enable automatic rebuilds
 ```
 
 Elsewhere, start the jupyter server in watch mode:

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "prettier": "npx prettier --write \"**/*{.ts,.tsx,.js,.jsx,.css,.json,.md}\"",
     "prettier:check": "npx prettier --list-different \"**/*{.ts,.tsx,.js,.jsx,.css,.json,.md}\"",
     "publish": "yarn run clean && yarn run build && lerna publish",
-    "test": "lerna run test"
+    "test": "lerna run test",
+    "watch": "lerna run watch --parallel"
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^4.8.1",
@@ -47,5 +48,8 @@
       "pre-commit": "lint-staged"
     }
   },
-  "private": true
+  "private": true,
+  "dependencies": {
+    "eslint-plugin-react-hooks": "^4.2.0"
+  }
 }

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -50,9 +50,11 @@
     "@lumino/widgets": "^1.16.1",
     "d3": "^5.5.0",
     "jupyterlab_toastify": "^4.1.3",
+    "react-cool-inview": "^2.0.7",
     "react-d3-graph": "^2.5.0",
     "react-virtualized-auto-sizer": "^1.0.2",
     "react-window": "^1.8.6",
+    "react-window-infinite-loader": "^1.0.7",
     "semver": "^6.0.0||^7.0.0",
     "typestyle": "^2.0.0"
   },
@@ -65,9 +67,11 @@
     "@types/react-d3-graph": "^2.3.4",
     "@types/react-virtualized-auto-sizer": "^1.0.0",
     "@types/react-window": "^1.8.2",
+    "@types/react-window-infinite-loader": "^1.0.5",
     "@types/semver": "^7.3.1",
     "jest": "^26.0.0",
     "react": "^17.0.0",
+    "react-cool-inview": "^2.0.7",
     "react-dom": "^17.0.0",
     "ts-jest": "^26.0.0"
   },

--- a/packages/common/src/CondaEnvWidget.tsx
+++ b/packages/common/src/CondaEnvWidget.tsx
@@ -8,7 +8,7 @@ import { IEnvironmentManager } from './tokens';
 /**
  * Widget size interface
  */
-interface ISize {
+export interface ISize {
   /**
    * Widget heigth
    */
@@ -23,7 +23,7 @@ interface ISize {
  * Widget encapsulating the Conda Environments & Packages Manager
  */
 export class CondaEnvWidget extends ReactWidget {
-  constructor(envModel: IEnvironmentManager) {
+  constructor(envModel?: IEnvironmentManager) {
     super();
     this._envModel = envModel;
   }
@@ -54,9 +54,9 @@ export class CondaEnvWidget extends ReactWidget {
   /**
    * Conda environment Manager
    */
-  private _envModel: IEnvironmentManager;
+  protected _envModel: IEnvironmentManager;
   /**
    * Signal triggering a React rendering if widget is resized
    */
-  private _resizeSignal = new Signal<CondaEnvWidget, ISize>(this);
+  protected _resizeSignal = new Signal<CondaEnvWidget, ISize>(this);
 }

--- a/packages/common/src/CondaStoreEnvWidget.tsx
+++ b/packages/common/src/CondaStoreEnvWidget.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import { Signal } from '@lumino/signaling';
+import { UseSignal } from '@jupyterlab/apputils';
+import { CondaEnvWidget, ISize } from './CondaEnvWidget'
+import { NbCondaStore } from './components/NbCondaStore';
+
+export class CondaStoreEnvWidget extends CondaEnvWidget {
+    render(): JSX.Element {
+        return (
+            <UseSignal
+                signal={this._resizeSignal}
+                initialArgs={{ height: 0, width: 0 }}
+            >
+                {(_, size): JSX.Element => (
+                    <NbCondaStore
+                        height={size.height}
+                        width={size.width}
+                    />
+                )}
+            </UseSignal>
+        );
+    }
+
+    // Possibly remove; we aren't using it inside NbCondaStore
+    protected _resizeSignal = new Signal<CondaStoreEnvWidget, ISize>(this);
+}

--- a/packages/common/src/components/CondaPkgPanel.tsx
+++ b/packages/common/src/components/CondaPkgPanel.tsx
@@ -13,7 +13,7 @@ import {
 import { PkgGraphWidget } from './PkgGraph';
 
 // Minimal panel width to show package description
-const PANEL_SMALL_WIDTH = 500;
+export const PANEL_SMALL_WIDTH = 500;
 
 /**
  * Package panel property
@@ -524,7 +524,7 @@ export class CondaPkgPanel extends React.Component<
   private _currentEnvironment = '';
 }
 
-namespace Style {
+export namespace Style {
   export const Panel = style({
     flexGrow: 1,
     borderLeft: '1px solid var(--jp-border-color2)'

--- a/packages/common/src/components/CondaStoreEnvItem.tsx
+++ b/packages/common/src/components/CondaStoreEnvItem.tsx
@@ -1,0 +1,69 @@
+import React from 'react'
+import { style } from 'typestyle'
+import { GlobalStyle } from './globalStyles'
+
+
+interface IEnvItemProps {
+    environment: string
+    namespace: string
+    selected?: boolean
+    onClick(environment: string, namespace: string): void
+    observe: (element?: HTMLElement) => void
+}
+
+export function CondaStoreEnvItem({
+    environment,
+    namespace,
+    selected,
+    onClick,
+    observe = null,
+}: IEnvItemProps): JSX.Element {
+    return (
+        <div
+            className={selected ? Style.SelectedItem : Style.Item}
+            onClick={() => {
+                onClick(environment, namespace)
+            }}
+            ref={observe}
+        >
+            {`${namespace}/${environment}`}
+        </div>
+    )
+}
+
+namespace Style {
+    export const Item = style(GlobalStyle.ListItem, {
+        padding: '2px 0 5px 5px',
+
+        $nest: {
+            '&:hover': {
+                backgroundColor: 'var(--jp-layout-color2)',
+                border: '1px solid var(--jp-border-color2)'
+            }
+        }
+    })
+
+    export const SelectedItem = style(GlobalStyle.ListItem, {
+        padding: '2px 0 5px 5px',
+        backgroundColor: 'var(--jp-brand-color1)',
+        color: 'var(--jp-ui-inverse-font-color1)',
+        border: '1px solid var(--jp-brand-color1)',
+        display: 'flex',
+        justifyContent: 'space-between',
+        alignItems: 'center',
+
+        $nest: {
+            '&::after': {
+                content: "' '",
+                display: 'inline-block',
+                padding: '0 5px',
+                width: 0,
+                height: 0,
+                borderTop: 'calc(var(--jp-ui-font-size1) / 2) solid transparent',
+                borderBottom: 'calc(var(--jp-ui-font-size1) / 2) solid transparent',
+                borderLeft:
+                    'calc(var(--jp-ui-font-size1) / 2) solid var(--jp-ui-inverse-font-color1)'
+            }
+        }
+    })
+}

--- a/packages/common/src/components/CondaStoreEnvList.tsx
+++ b/packages/common/src/components/CondaStoreEnvList.tsx
@@ -1,0 +1,106 @@
+import React from 'react'
+import { style } from 'typestyle'
+import { CONDA_ENVIRONMENT_PANEL_ID } from '../constants'
+import { ICondaStoreEnvironment } from '../condaStore'
+import { CondaStoreEnvItem } from './CondaStoreEnvItem'
+import { CondaEnvToolBar, ENVIRONMENT_TOOLBAR_HEIGHT } from './CondaEnvToolBar'
+import useInView from 'react-cool-inview'
+
+export const ENVIRONMENT_PANEL_WIDTH = 250;
+
+interface ICondaStoreEnvListProps {
+    height: number
+    isLoading: boolean
+    environments: Array<ICondaStoreEnvironment>
+    selected: string
+    onSelectedChange(environment: string, namespace: string): void
+    onCreate(): void
+    onClone(): void
+    onImport(): void
+    onExport(): void
+    onRefresh(): void
+    onRemove(): void
+    onBottomHit(): Promise<void>
+}
+
+export function CondaStoreEnvList({
+    height,
+    isLoading,
+    environments,
+    selected,
+    onSelectedChange,
+    onCreate,
+    onClone,
+    onImport,
+    onExport,
+    onRefresh,
+    onRemove,
+    onBottomHit,
+}: ICondaStoreEnvListProps): JSX.Element {
+    const { observe } = useInView({
+        onChange: async ({ inView, unobserve, observe }) => {
+            if (inView) {
+                unobserve()
+                await onBottomHit()
+                observe()
+            }
+        }
+    })
+
+    // Forbid clone and removing the environment named "base" (base conda environment)
+    // and the default one (i.e. the one containing JupyterLab)
+    const isDefault = selected === 'base'
+    const listItems = environments.map((env, index) => {
+        return (
+            <CondaStoreEnvItem
+                environment={env.name}
+                namespace={env.namespace.name}
+                key={`${env.namespace.name}/${env.name}`}
+                selected={selected ? env.name === selected : false}
+                onClick={onSelectedChange}
+                observe={index === environments.length-1 ? observe: null}
+            />
+        )
+    })
+
+    return (
+        <div className={Style.Panel}>
+            <CondaEnvToolBar
+                isBase={isDefault}
+                isPending={isLoading}
+                onCreate={onCreate}
+                onClone={onClone}
+                onImport={onImport}
+                onExport={onExport}
+                onRefresh={onRefresh}
+                onRemove={onRemove}
+            />
+            <div
+                id={CONDA_ENVIRONMENT_PANEL_ID}
+                className={Style.ListEnvs(
+                    height - ENVIRONMENT_TOOLBAR_HEIGHT - 32
+                )}
+            >
+                {listItems}
+            </div>
+        </div>
+    )
+}
+
+namespace Style {
+    export const Panel = style({
+        flexGrow: 0,
+        flexShrink: 0,
+        display: 'flex',
+        flexDirection: 'column',
+        overflow: 'hidden',
+        width: ENVIRONMENT_PANEL_WIDTH
+    })
+
+    export const ListEnvs = (height: number): string => style({
+        height: height,
+        overflowY: 'auto',
+        display: 'flex',
+        flexDirection: 'column'
+    })
+}

--- a/packages/common/src/components/CondaStorePkgList.tsx
+++ b/packages/common/src/components/CondaStorePkgList.tsx
@@ -1,0 +1,480 @@
+import React from 'react'
+import { faSquare } from '@fortawesome/free-regular-svg-icons/faSquare'
+import { faCheckSquare } from '@fortawesome/free-solid-svg-icons/faCheckSquare'
+import { faExternalLinkAlt } from '@fortawesome/free-solid-svg-icons/faExternalLinkAlt'
+import { faExternalLinkSquareAlt } from '@fortawesome/free-solid-svg-icons/faExternalLinkSquareAlt'
+import { faMinusSquare } from '@fortawesome/free-solid-svg-icons/faMinusSquare'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { HTMLSelect } from '@jupyterlab/ui-components'
+import AutoSizer from 'react-virtualized-auto-sizer'
+import { FixedSizeList, ListChildComponentProps } from 'react-window'
+import useInView from 'react-cool-inview'
+import { classes, style } from 'typestyle'
+import { NestedCSSProperties } from 'typestyle/lib/types'
+import {
+    CONDA_PACKAGES_PANEL_ID,
+    CONDA_PACKAGE_SELECT_CLASS
+} from '../constants'
+import { ICondaStorePackage } from '../condaStore'
+import { ICondaStorePackageMapEntry } from './CondaStorePkgPanel'
+
+const HEADER_HEIGHT = 29
+
+interface IPkgListProps {
+    height: number
+    packages: Map<string, ICondaStorePackageMapEntry>
+    onPkgClick(pkg: ICondaStorePackage): void
+    onPkgChange(pkg: ICondaStorePackage, version: string): void
+    onPkgGraph(pkg: ICondaStorePackage): void
+    onBottomHit(): Promise<void>
+    isLoading: boolean
+    nPackages: number
+}
+
+function InfiniteListWidget({
+    onPkgGraph,
+    onPkgChange,
+    onPkgClick,
+    height,
+    width,
+    packages,
+    observe,
+}: {
+    onPkgGraph: (pkg: ICondaStorePackage) => void,
+    onPkgChange: (pkg: ICondaStorePackage, version: string) => void,
+    onPkgClick: (pkg: ICondaStorePackage) => void,
+    height: number,
+    width: number,
+    packages: Map<string, ICondaStorePackageMapEntry>,
+    observe: (element?: HTMLElement) => void,
+}): JSX.Element {
+
+    return (
+        <FixedSizeList
+            height={Math.max(0, height - HEADER_HEIGHT)}
+            overscanCount={3}
+            itemCount={packages.size}
+            itemData={packages}
+            itemKey={
+                (
+                    index: number,
+                    data: Map<string, ICondaStorePackageMapEntry>
+                ): React.Key => {
+                    return indexMap(data, index).key
+                }
+            }
+            itemSize={40}
+            width={width}
+        >
+            {generateRowRenderer(
+                onPkgGraph,
+                onPkgChange,
+                onPkgClick,
+                observe,
+            )}
+        </FixedSizeList>
+    )
+}
+
+function indexMap<K, V>(map: Map<K, V>, index: number): {key: K, value: V} {
+    const key = Array.from(map.keys())[index]
+    return {key, value: map.get(key)}
+}
+
+function generateRowRenderer(
+    onPkgGraph: (pkg: ICondaStorePackage) => void,
+    onPkgChange: (pkg: ICondaStorePackage, version: string) => void,
+    onPkgClick: (pkg: ICondaStorePackage) => void,
+    observe: (element?: HTMLElement) => void
+) {
+    function rowRenderer({
+        data,
+        index,
+        style,
+    }: ListChildComponentProps): JSX.Element {
+        const {value: pkgObj}: {value: ICondaStorePackageMapEntry} = indexMap(data, index)
+
+        // Get the package with the highest version number
+        const pkg = pkgObj.packages[pkgObj.packages.length-1]
+        return (
+            <div
+                className={rowClassName(index, false)}
+                style={style}
+                onClick={(): void => {
+                    onPkgClick(pkg)
+                }}
+                ref={index === data.size-1 ? observe : null}
+                role="row"
+            >
+                <IconRender version_installed={pkgObj.versionInstalled} version_selected=''/>
+                <NameRender name={pkg.name} home={pkg.home} />
+                <div
+                    className={classes(Style.CellSummary, Style.DescriptionSize)}
+                    role="gridcell"
+                    title={pkg?.summary}
+                >
+                    {pkg?.summary}
+                </div>
+                <VersionRender versionInstalled={pkgObj.versionInstalled} />
+                <div className={classes(Style.Cell, Style.ChangeSize)} role="gridcell">
+                    <ChangeRender
+                        pkg={pkg}
+                        onPkgChange={onPkgChange}
+                    />
+                </div>
+                <div
+                    className={classes(Style.Cell, Style.ChannelSize)}
+                    role="gridcell"
+                    title={pkg?.channel}
+                >
+                    {pkg?.channel}
+                </div>
+            </div>
+        )
+    }
+    return rowRenderer
+}
+
+export function CondaStorePkgList({
+    height,
+    packages,
+    onPkgClick,
+    onPkgChange,
+    onPkgGraph,
+    onBottomHit,
+    isLoading,
+    nPackages,
+}: IPkgListProps): JSX.Element {
+    const { observe } = useInView({
+        rootMargin: '200px 0px',
+        onChange: async ({ inView, unobserve, observe }) => {
+            if (inView) {
+                unobserve()
+                await onBottomHit()
+                observe()
+            }
+        }
+    })
+
+    return (
+        <div id={CONDA_PACKAGES_PANEL_ID} role="grid">
+            <AutoSizer disableHeight>
+                {({ width }): JSX.Element => {
+                    return (
+                        <>
+                            <div
+                                className={Style.RowHeader}
+                                style={{ width: width }}
+                                role="row"
+                            >
+                                <div
+                                    className={classes(Style.Cell, Style.StatusSize)}
+                                    role="columnheader"
+                                >
+                                </div>
+                                <div
+                                    className={classes(Style.Cell, Style.NameSize)}
+                                    role="columnheader"
+                                >
+                                    Name
+                                </div>
+                                <div
+                                    className={classes(Style.Cell, Style.DescriptionSize)}
+                                    role="columnheader"
+                                >
+                                    Description
+                                </div>
+                                <div
+                                    className={classes(Style.Cell, Style.VersionSize)}
+                                    role="columnheader"
+                                >
+                                    Version
+                                </div>
+                                <div
+                                    className={classes(Style.Cell, Style.ChangeSize)}
+                                    role="columnheader"
+                                >
+                                    Change To
+                                </div>
+                                <div
+                                    className={classes(Style.Cell, Style.ChannelSize)}
+                                    role="columnheader"
+                                >
+                                    Channel
+                                </div>
+                            </div>
+                            <InfiniteListWidget
+                                onPkgGraph={onPkgGraph}
+                                onPkgChange={onPkgChange}
+                                onPkgClick={onPkgClick}
+                                height={height}
+                                width={width}
+                                observe={observe}
+                                packages={packages}
+                            />
+                        </>
+                    )
+                }}
+            </AutoSizer>
+        </div>
+    )
+}
+
+function rowClassName(index: number, isSelected: boolean): string {
+    if (index >= 0) {
+        return index % 2 === 0
+            ? Style.RowEven(isSelected)
+            : Style.RowOdd(isSelected)
+    }
+}
+
+function ChangeRender({
+    pkg,
+    onPkgChange,
+}: {
+    pkg: ICondaStorePackage,
+    onPkgChange(pkg: ICondaStorePackage, version: string): void
+}): JSX.Element {
+    return (
+        <div className={'lm-Widget'}>
+            <HTMLSelect
+                className={classes(Style.VersionSelection, CONDA_PACKAGE_SELECT_CLASS)}
+                value={pkg.version}
+                onClick={(evt: React.MouseEvent): void => {
+                    evt.stopPropagation()
+                }}
+                onChange={(evt: React.ChangeEvent<HTMLSelectElement>): void =>
+                    onPkgChange(pkg, evt.target.value)
+                }
+                aria-label="Package versions"
+            >
+                <option key="-3" value={'none'}>
+                    Remove
+                </option>
+                {
+                    // {!pkg?.version_installed && (
+                    //     <option key="-2" value={''}>
+                    //     Install
+                    //     </option>
+                    // )}
+                    // {pkg?.updatable && (
+                    //     <option key="-1" value={''}>
+                    //     Update
+                    //     </option>
+                    // )}
+                    // {pkg?.available_version.map((v) => (
+                    //     <option key={v} value={v}>
+                    //     {v}
+                    //     </option>
+                    // ))}
+                }
+            </HTMLSelect>
+        </div>
+    )
+}
+
+function IconRender({
+    version_selected,
+    version_installed,
+}: {
+    version_installed: string
+    version_selected: string
+}): JSX.Element {
+    let icon: JSX.Element;
+    if (version_installed) {
+        if (version_selected === 'none') {
+            icon = (
+                <FontAwesomeIcon
+                    icon={faMinusSquare}
+                    style={{ color: 'var(--jp-error-color1)' }}
+                />
+            )
+        } else if (version_selected !== version_installed) {
+            icon = (
+                <FontAwesomeIcon
+                    icon={faExternalLinkSquareAlt}
+                    style={{ color: 'var(--jp-accent-color1)' }}
+                />
+            )
+        } else {
+            icon = (
+                <FontAwesomeIcon
+                    icon={faCheckSquare}
+                    style={{ color: 'var(--jp-brand-color1)' }}
+                />
+            )
+        }
+    } else if (version_selected !== 'none') {
+        icon = (
+            <FontAwesomeIcon
+                icon={faCheckSquare}
+                style={{ color: 'var(--jp-brand-color1)' }}
+            />
+        )
+    } else {
+        icon = (
+            <FontAwesomeIcon
+                icon={faSquare}
+                style={{ color: 'var(--jp-ui-font-color2)' }}
+            />
+        )
+    }
+
+    return (
+        <div className={classes(Style.Cell, Style.StatusSize)} role="gridcell">
+            {icon}
+        </div>
+    )
+
+}
+
+function NameRender({
+    home,
+    name,
+}: {
+    home: string,
+    name: string,
+}): JSX.Element {
+    let content: JSX.Element;
+    if (home?.length > 0) {
+        content = (
+            <a
+                className={Style.Link}
+                href={home}
+                onClick={(evt): void => evt.stopPropagation()}
+                target="_blank"
+                rel="noopener noreferrer"
+            >
+                {name} <FontAwesomeIcon icon={faExternalLinkAlt} />
+            </a>
+        )
+    } else {
+        content = <span>{name}</span>
+    }
+
+    return (
+        <div className={classes(Style.Cell, Style.NameSize)} role="gridcell">
+            {content}
+        </div>
+    )
+}
+
+function VersionRender({
+    versionInstalled,
+    updatable,
+}: {
+    versionInstalled: string,
+    updatable?: boolean
+}): JSX.Element {
+    return (
+        <div className={classes(Style.Cell, Style.VersionSize)} role="gridcell">
+            <a
+                className={updatable ? Style.Updatable : undefined}
+                href="#"
+                onClick={(evt): void => {
+                    evt.stopPropagation()
+                    // onPkgGraph(pkg)
+                }}
+                rel="noopener noreferrer"
+                title="Show dependency graph"
+            >
+                {versionInstalled}
+            </a>
+        </div>
+    )
+}
+
+
+namespace Style {
+    const row: NestedCSSProperties = {
+        display: 'flex',
+        flexDirection: 'row',
+        alignItems: 'center'
+    }
+
+    export const RowHeader = style(row, {
+        color: 'var(--jp-ui-font-color1)',
+        fontWeight: 'bold',
+        fontSize: 'var(--jp-ui-font-size2)',
+        height: HEADER_HEIGHT,
+        boxSizing: 'border-box',
+        paddingRight: 17 // Take into account the package list scrollbar width
+    })
+
+    const rowContent: NestedCSSProperties = {
+        fontSize: 'var(--jp-ui-font-size1)',
+        color: 'var(--jp-ui-font-color0)',
+        lineHeight: 'normal',
+        $nest: {
+            '&:hover': {
+                backgroundColor: 'var(--jp-layout-color3)'
+            }
+        }
+    }
+
+    export const RowEven = (selected: boolean): string =>
+        style(row, rowContent, {
+            background: selected ? 'var(--jp-brand-color3)' : 'unset'
+        })
+
+    export const RowOdd = (selected: boolean): string =>
+        style(row, rowContent, {
+            background: selected
+                ? 'var(--jp-brand-color3)'
+                : 'var(--jp-layout-color2)'
+        })
+
+    export const Cell = style({
+        margin: '0px 2px',
+        whiteSpace: 'nowrap',
+        textOverflow: 'ellipsis',
+        overflow: 'hidden'
+    })
+
+    export const StatusSize = style({ flex: '0 0 12px', padding: '0px 2px' })
+    export const NameSize = style({ flex: '1 1 200px' })
+    export const DescriptionSize = style({ flex: '5 5 250px' })
+    export const VersionSize = style({ flex: '0 0 90px' })
+    export const ChangeSize = style({ flex: '0 0 120px' })
+    export const ChannelSize = style({ flex: '1 1 120px' })
+
+    export const CellSummary = style({
+        margin: '0px 2px',
+        alignSelf: 'flex-start',
+        whiteSpace: 'normal',
+        height: '100%',
+        overflow: 'hidden'
+    })
+
+    export const SortButton = style({
+        transform: 'rotate(180deg)',
+        marginLeft: '10px',
+        color: 'var(--jp-ui-font-color2)',
+        border: 'none',
+        backgroundColor: 'var(--jp-layout-color0)',
+        fontSize: 'var(--jp-ui-font-size1)'
+    })
+
+    export const Link = style({
+        $nest: {
+            '&:hover': {
+                textDecoration: 'underline'
+            }
+        }
+    })
+
+    export const Updatable = style({
+        color: 'var(--jp-brand-color0)',
+
+        $nest: {
+            '&::before': {
+                content: "'↗️'",
+                paddingRight: 2
+            }
+        }
+    })
+
+    export const VersionSelection = style({
+        width: '100%'
+    })
+}

--- a/packages/common/src/components/CondaStorePkgPanel.tsx
+++ b/packages/common/src/components/CondaStorePkgPanel.tsx
@@ -1,0 +1,268 @@
+import React, {useState, useEffect, useCallback} from 'react'
+import {
+  CondaPkgToolBar,
+  PACKAGE_TOOLBAR_HEIGHT,
+  PkgFilters
+} from './CondaPkgToolBar'
+import {Style} from './CondaPkgPanel'
+import { CondaStorePkgList } from './CondaStorePkgList'
+import {
+    fetchPackages,
+    fetchEnvironmentPackages,
+    ICondaStorePackage
+} from '../condaStore'
+
+interface ICondaStorePkgPanelProps {
+    height: number
+    width: number
+    namespace: string
+    environment: string
+}
+
+export interface ICondaStorePackageMapEntry {
+    versionInstalled: string
+    packages: Array<ICondaStorePackage>
+}
+
+export function CondaStorePkgPanel({
+    height,
+    width,
+    environment,
+    namespace,
+}: ICondaStorePkgPanelProps): JSX.Element {
+    const [searchTerm, setSearchTerm] = useState('')
+    const [activeFilter, setActiveFilter] = useState(PkgFilters.All)
+    const [isLoading, setIsLoading] = useState(false)
+    const [selected, setSelected] = useState([])
+    const [hasUpdate, setHasUpdate] = useState(false)
+    const [packages, setPackages] = useState(new Map())
+    const [nPackages, setNPackages] = useState(0)
+
+    const [packagesPage, setPackagesPage] = useState(1)
+    const [hasMoreData, setHasMoreData] = useState(true)
+
+    const [installedPackages, setInstalledPackages] = useState([])
+    const [installedPackagesPage, setInstalledPackagesPage] = useState(1)
+    const [nInstalledPackages, setNInstalledPackages] = useState(0)
+    const [hasMoreInstalledPackages, setHasMoreInstalledPackages] = useState(true)
+
+    function handleCategoryChanged(event: React.ChangeEvent<HTMLSelectElement>): void {
+        return
+    }
+
+    function handleSearch() {
+        return
+    }
+
+    function handleUpdateAll() {
+        return
+    }
+
+    function handleApply() {
+        return
+    }
+
+    function handleCancel() {
+        return
+    }
+
+    async function handleRefreshPackages() {
+        await refreshPackages()
+    }
+
+    function handleClick() {
+        return
+    }
+
+    function handleVersionSelection() {
+        return
+    }
+
+    function handleDependenciesGraph() {
+        return
+    }
+
+    const groupPackages = useCallback((
+        pkgs: Array<ICondaStorePackage>
+    ): Map<string, ICondaStorePackageMapEntry> => {
+        const grouped = new Map()
+        pkgs.forEach((pkg) => {
+            if (grouped.has(pkg.name)) {
+                const pkgObj = grouped.get(pkg.name)
+                grouped.set(
+                    pkg.name,
+                    {
+                        ...pkgObj,
+                        packages: [...pkgObj.packages, pkg],
+                    }
+                )
+            } else {
+                grouped.set(
+                    pkg.name,
+                    {
+                        versionInstalled: null,
+                        packages: [pkg],
+                    }
+                )
+            }
+        })
+        return sortByVersion(grouped)
+    }, [])
+
+    const getInstalledPackages = useCallback(async (): Promise<Array<ICondaStorePackage>> => {
+        const {count, data, page, size} = await fetchEnvironmentPackages(
+            namespace,
+            environment,
+            installedPackagesPage,
+        )
+        setNInstalledPackages(count)
+        setInstalledPackagesPage(installedPackagesPage+1)
+        setHasMoreInstalledPackages(count > page*size)
+        return data
+    }, [environment, namespace, installedPackagesPage])
+
+    const getAvailablePackages = useCallback(async (): Promise<Array<ICondaStorePackage>> => {
+        const {count, data, page, size} = await fetchPackages(packagesPage)
+        setNPackages(count)
+        setPackagesPage(packagesPage+1)
+        setHasMoreData(count > page*size)
+        return data
+    }, [packagesPage])
+
+    const loadPackages = useCallback(async () => {
+        if (hasMoreData && !isLoading) {
+            setIsLoading(true)
+
+            // Get new packages, group by name, and then merge with existing packages
+            // available packages we've fetched so far
+            const newPackages = mergeMaps(
+                packages,
+                groupPackages(await getAvailablePackages())
+            )
+            // Get the name of the last available package
+            const lastPackage = Array.from(newPackages.keys())[newPackages.size-1]
+
+            let installedPkgs = installedPackages
+            let lastInstalled = installedPkgs.length > 0 ? installedPkgs[installedPkgs.length-1].name : undefined
+
+            // If there are more installed packages to fetch, and either
+            // 1. No installed packages have been fetched, or
+            // 2. The last installed package comes alphabetically before the last available package
+            // Then fetch more packages until either we run out or have fetched enough to be further
+            // along in the alphabet than we are with the available packages.
+            while (
+                hasMoreInstalledPackages
+                && (
+                    installedPkgs.length === 0
+                    || lastInstalled.localeCompare(lastPackage) < 0
+                )
+            ) {
+                installedPkgs = [...installedPkgs, ...await getInstalledPackages()]
+                lastInstalled = installedPkgs.length > 0 ? installedPkgs[installedPkgs.length-1].name : undefined
+            }
+
+            // Update the state with the installed packages; then update each package with the
+            // installed version, if any
+            setInstalledPackages(installedPkgs)
+            installedPkgs.forEach(({name, version}) => {
+                if (newPackages.has(name)) {
+                    newPackages.set(name, {...newPackages.get(name), versionInstalled: version})
+                }
+            })
+            setPackages(newPackages)
+            setIsLoading(false)
+        }
+    }, [packages, hasMoreData, isLoading, groupPackages, getAvailablePackages, getInstalledPackages, hasMoreInstalledPackages, installedPackages])
+
+    function sortByVersion(
+        pkgMap: Map<string, ICondaStorePackageMapEntry>
+    ): Map<string, ICondaStorePackageMapEntry> {
+        const sorted = new Map()
+        pkgMap.forEach((pkgObj, name) => {
+            sorted.set(
+                name,
+                {
+                    ...pkgObj,
+                    packages: pkgObj.packages.sort((element1: ICondaStorePackage, element2: ICondaStorePackage) => {
+                        return element1.version.localeCompare(
+                            element2.version,
+                            undefined,
+                            {numeric: true, sensitivity: 'base'}
+                        )
+                    })
+                }
+            )
+        })
+        return sorted
+    }
+
+    function mergeMaps(
+        map1: Map<string, ICondaStorePackageMapEntry>,
+        map2: Map<string, ICondaStorePackageMapEntry>,
+    ): Map<string, ICondaStorePackageMapEntry> {
+        const merged = new Map(map1)
+        map2.forEach((value, key) => {
+            if (merged.has(key)) {
+                merged.set(
+                    key,
+                    {
+                        versionInstalled: value.versionInstalled === null ? merged.get(key).versionInstalled : value.versionInstalled,
+                        packages: [...merged.get(key).packages, ...value.packages],
+                    }
+                )
+            } else {
+                merged.set(key, value)
+            }
+        })
+        return merged
+    }
+
+
+    async function refreshPackages() {
+        setPackages(new Map([]))
+        setPackagesPage(1)
+        setNPackages(0)
+        setHasMoreData(true)
+    }
+
+    useEffect(() => {
+        if (
+            environment !== ''
+            && namespace !== ''
+            && nPackages === 0
+            && hasMoreData
+            && packagesPage === 1
+            && packages.size === 0
+        ) {
+            loadPackages()
+        }
+    }, [loadPackages, environment, namespace, nPackages, hasMoreData, packagesPage, packages])
+
+    return (
+        <div className={Style.Panel}>
+            <CondaPkgToolBar
+                isPending={isLoading}
+                category={activeFilter}
+                hasSelection={selected.length > 0}
+                hasUpdate={hasUpdate}
+                searchTerm={searchTerm}
+                onCategoryChanged={handleCategoryChanged}
+                onSearch={handleSearch}
+                onUpdateAll={handleUpdateAll}
+                onApply={handleApply}
+                onCancel={handleCancel}
+                onRefreshPackages={handleRefreshPackages}
+            />
+            <CondaStorePkgList
+                height={height - PACKAGE_TOOLBAR_HEIGHT}
+                packages={packages}
+                onPkgClick={handleClick}
+                onPkgChange={handleVersionSelection}
+                onPkgGraph={handleDependenciesGraph}
+                onBottomHit={loadPackages}
+                isLoading={isLoading}
+                nPackages={nPackages}
+            />
+        </div>
+    )
+}

--- a/packages/common/src/components/NbConda.tsx
+++ b/packages/common/src/components/NbConda.tsx
@@ -22,7 +22,7 @@ export interface ICondaEnvProps {
   /**
    * Environment manager
    */
-  model: IEnvironmentManager;
+  model?: IEnvironmentManager;
 }
 
 /**
@@ -360,7 +360,7 @@ export class NbConda extends React.Component<ICondaEnvProps, ICondaEnvState> {
       this.setState({ isLoading: true });
       try {
         const newState: Partial<ICondaEnvState> = {
-          environments: await this.props.model.environments
+          environments: await this.props.model.environments,
         };
         if (this.state.currentEnvironment === undefined) {
           newState.environments.forEach(env => {
@@ -378,6 +378,7 @@ export class NbConda extends React.Component<ICondaEnvProps, ICondaEnvState> {
         if (error !== 'cancelled') {
           console.error(error);
           INotification.error(error.message);
+          this.setState({isLoading: false})
         }
       }
     }
@@ -415,7 +416,7 @@ export class NbConda extends React.Component<ICondaEnvProps, ICondaEnvState> {
   }
 }
 
-namespace Style {
+export namespace Style {
   export const Panel = style({
     width: '100%',
     display: 'flex',

--- a/packages/common/src/components/NbCondaStore.tsx
+++ b/packages/common/src/components/NbCondaStore.tsx
@@ -1,0 +1,108 @@
+import React, {useState, useEffect, useCallback} from 'react'
+// import { INotification } from 'jupyterlab_toastify'
+import { fetchEnvironments } from '../condaStore'
+import { Style } from './NbConda'
+import { CondaStorePkgPanel } from './CondaStorePkgPanel'
+import { CondaStoreEnvList, ENVIRONMENT_PANEL_WIDTH } from './CondaStoreEnvList';
+
+export interface INbCondaStoreProps {
+    height: number
+    width: number
+}
+
+export function NbCondaStore({
+    height,
+    width,
+}: INbCondaStoreProps): JSX.Element {
+
+    const [isLoading, setIsLoading] = useState(false)
+    const [activeEnvironment, setActiveEnvironment] = useState('')
+    const [activeNamespace, setActiveNamespace] = useState('')
+
+    // Environments contains namespace info; see ICondaStoreEnvironment
+    const [environments, setEnvironments] = useState([])
+    const [environmentPage, setEnvironmentPage] = useState(1)
+    const [hasMoreData, setHasMoreData] = useState(true)
+
+    /**
+     * Load the environments; more requests are made when the user scrolls down.
+     */
+    const loadEnvironments = useCallback(async () => {
+        if (hasMoreData && !isLoading) {
+            setIsLoading(true)
+            const {count, data, page, size} = await fetchEnvironments(environmentPage)
+            setEnvironments([...environments, ...data])
+            setEnvironmentPage(environmentPage+1)
+            setHasMoreData(count > page*size)
+            setIsLoading(false)
+        }
+    }, [hasMoreData, isLoading, environments, environmentPage])
+
+    async function environmentChange(environment: string, namespace: string): Promise<void> {
+        setActiveEnvironment(environment)
+        setActiveNamespace(namespace)
+    }
+
+    async function createEnvironment() {
+        return
+    }
+
+    async function cloneEnvironment() {
+        return
+    }
+
+    async function importEnvironment() {
+        return
+    }
+
+    async function exportEnvironment() {
+        return
+    }
+
+    async function refreshEnvironments() {
+        setActiveEnvironment('')
+        setActiveNamespace('')
+        setEnvironments([])
+        setEnvironmentPage(1)
+        setHasMoreData(true)
+    }
+
+    async function removeEnvironment() {
+        return
+    }
+
+    useEffect(() => {
+        if (
+            environments.length === 0
+            && hasMoreData
+            && environmentPage === 1
+        ) {
+            loadEnvironments()
+        }
+    }, [loadEnvironments, environments, hasMoreData, environmentPage])
+
+    return (
+        <div className={Style.Panel}>
+            <CondaStoreEnvList
+                height={height}
+                isLoading={isLoading}
+                environments={environments}
+                selected={activeEnvironment}
+                onSelectedChange={environmentChange}
+                onCreate={createEnvironment}
+                onClone={cloneEnvironment}
+                onImport={importEnvironment}
+                onExport={exportEnvironment}
+                onRefresh={refreshEnvironments}
+                onRemove={removeEnvironment}
+                onBottomHit={loadEnvironments}
+            />
+            <CondaStorePkgPanel
+                height={height}
+                width={width - ENVIRONMENT_PANEL_WIDTH}
+                namespace={activeNamespace}
+                environment={activeEnvironment}
+            />
+        </div>
+    )
+}

--- a/packages/common/src/condaStore.ts
+++ b/packages/common/src/condaStore.ts
@@ -1,0 +1,151 @@
+const baseUrl = 'http://localhost:5000/api/v1'
+
+export interface ICondaStoreEnvironment {
+    name: string
+    build_id: number
+    id: number
+    namespace: {
+        id: number
+        name: string
+    }
+}
+
+export interface ICondaStorePackage {
+    name: string
+    version: string
+    channel_id: number
+    id: number
+    license: string
+    sha256: string
+
+    // Required in the CondaStorePkgList, but not in the API
+    summary?: string
+    channel?: string
+    updatable?: boolean
+    home?: string
+    version_installed?: string
+    available_version?: Array<string>
+}
+
+export interface ICondaStoreChannel {
+    id: number
+    last_update: string
+    name: string
+}
+
+interface IPaginatedResult<T> {
+    count?: number
+    data?: Array<T>
+    page?: number
+    size?: number
+    status?: string
+}
+
+
+/**
+ * Fetch all conda-store environments.
+ *
+ * @async
+ * @return {Promise<IPaginatedResult<ICondaStoreEnvironment>>} All environments visible to conda-store.
+ */
+export async function fetchEnvironments(page = 1, size = 100): Promise<IPaginatedResult<ICondaStoreEnvironment>> {
+    const response = await fetch(`${baseUrl}/environment/?page=${page}&size=${size}`)
+    if (response.ok) {
+        return await response.json()
+    } else {
+        return {}
+    }
+}
+
+/**
+ * Search all packages (both installed and not installed) for a package.
+ *
+ * @async
+ * @param {string} term - Search term; both name and descriptions are searched
+ * @return {Promise<Array<ICondaStorePackage>>} Packages matching the search term.
+ */
+export async function searchPackages(term: string): Promise<Array<ICondaStorePackage>> {
+    const response = await fetch(`${baseUrl}/package/?search=${term}`)
+    if (response.ok) {
+        return await response.json()
+    } else {
+        return []
+    }
+}
+
+/**
+ * Fetch the packages available in the conda-store database.
+ *
+ * Results are distinct on name and version.
+ * @async
+ * @return {Promise<IPaginatedResult<ICondaStorePackage>>} List of available packages
+ */
+export async function fetchPackages(page = 1, size = 100): Promise<IPaginatedResult<ICondaStorePackage>> {
+    const response = await fetch(`${baseUrl}/package/?page=${page}&size=${size}&distinct_on=name&distinct_on=version`)
+    if (response.ok) {
+        return await response.json()
+    } else {
+        return {}
+    }
+}
+
+/**
+ * List the installed packages for the given environment and namespace.
+ *
+ * @async
+ * @param {string} namespace - Name of the namespace to be searched
+ * @param {string} environment - Name of the environment to be searched
+ * @return {Promise<IPaginatedResult<ICondaStorePackage>>} List of packages in the given namespace/environment
+ * combination
+ */
+export async function fetchEnvironmentPackages(
+    namespace: string,
+    environment: string,
+    page = 1,
+    size = 100,
+): Promise<IPaginatedResult<ICondaStorePackage>> {
+    if ((namespace === undefined) || (environment === undefined)) {
+        console.error(
+            `Error: invalid arguments to fetchEnvironmentPackages: envNamespace ${namespace} envName ${environment}`
+        )
+        return {}
+    }
+
+    let response = await fetch(`${baseUrl}/environment/${namespace}/${environment}/`)
+
+    if (response.ok) {
+        const {data} = await response.json()
+        response = await fetch(
+            `${baseUrl}/build/${data.current_build_id}/packages/?page=${page}&size=${size}`
+        )
+        if (response.ok) {
+            return response.json()
+        }
+    }
+    return {}
+}
+
+export async function fetchBuildPackages(
+    build_id: number
+): Promise<IPaginatedResult<ICondaStorePackage>> {
+    const response = await fetch(`${baseUrl}/build/${build_id}/`)
+    if (response.ok) {
+        return await response.json()
+    }
+    return {}
+}
+
+/**
+ * Fetch the channels. Channels are remote repositories containing conda packages.
+ *
+ * @async
+ * @return {Promise<Array<ICondaStoreChannel>>} List of all possible channels from which packages
+ * may be downloaded..
+ */
+export async function fetchChannels(): Promise<Array<ICondaStoreChannel>> {
+    const response = await fetch(`${baseUrl}/channel/`)
+    if (response.ok) {
+        return await response.json()
+    }
+    return []
+}

--- a/packages/common/src/hooks/infiniteScroll.tsx
+++ b/packages/common/src/hooks/infiniteScroll.tsx
@@ -1,0 +1,20 @@
+import {useCallback} from 'react'
+
+export default function useInfiniteScroll(
+    onIntersect: () => void
+): (node: HTMLDivElement) => void {
+
+    const callback = useCallback((entries) => {
+        if (entries[0].isIntersecting) {
+            onIntersect()
+        }
+    }, [onIntersect])
+
+    const infiniteScrollRef = useCallback((node) => {
+        if (node) {
+            const intersectionObserver = new IntersectionObserver(callback)
+            intersectionObserver.observe(node)
+        }
+    }, [callback])
+    return infiniteScrollRef
+}

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -1,4 +1,5 @@
 export { CondaEnvWidget } from './CondaEnvWidget';
+export { CondaStoreEnvWidget } from './CondaStoreEnvWidget';
 export * from './constants';
 export { condaIcon } from './icon';
 export { CondaEnvironments } from './services';

--- a/packages/common/src/tokens.ts
+++ b/packages/common/src/tokens.ts
@@ -82,11 +82,14 @@ export namespace Conda {
   /**
    * Description of the REST API response for each environment
    */
-  export interface IEnvironment {
+  export interface IEnvironmentBase {
     /**
      * Environment name
      */
     name: string;
+  }
+
+  export interface IEnvironment extends IEnvironmentBase {
     /**
      * Environment path
      */
@@ -233,14 +236,14 @@ export namespace Conda {
   export interface IPackage {
     name: string;
     version: Array<string>;
-    build_number: Array<number>;
-    build_string: Array<string>;
+    build_number?: Array<number>;
+    build_string?: Array<string>;
     channel: string;
-    platform: string;
-    summary: string;
-    home: string;
-    keywords: string;
-    tags: string;
+    platform?: string;
+    summary?: string;
+    home?: string;
+    keywords?: string;
+    tags?: string;
     version_installed?: string;
     version_selected?: string;
     updatable?: boolean;

--- a/packages/navigator/webpack.config.js
+++ b/packages/navigator/webpack.config.js
@@ -59,7 +59,8 @@ module.exports = {
     }),
     new BundleAnalyzerPlugin({
       analyzerMode: 'static',
-      reportFilename: path.resolve(__dirname, 'webpack-report.html')
+      reportFilename: path.resolve(__dirname, 'webpack-report.html'),
+      openAnalyzer: false
     })
   ]
 };

--- a/tsconfig-base.json
+++ b/tsconfig-base.json
@@ -14,7 +14,7 @@
     "moduleResolution": "node",
     "noEmitOnError": true,
     "noImplicitAny": true,
-    "noUnusedLocals": true,
+    "noUnusedLocals": false,
     "preserveWatchOutput": true,
     "resolveJsonModule": true,
     "sourceMap": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2859,6 +2859,21 @@
   dependencies:
     "@types/react" "*"
 
+"@types/react-window-infinite-loader@^1.0.5":
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/@types/react-window-infinite-loader/-/react-window-infinite-loader-1.0.5.tgz#32469a6a47438d9ebf1b5f5719943f494ea0abdf"
+  integrity sha512-3v45+4oBNJpSroULtb2EgTJyyK4pCjOMCg+RT/HnA3or5zY4jYufv6uH9NWPyLv0nx8dqt1s4nJqHilfthwKSw==
+  dependencies:
+    "@types/react" "*"
+    "@types/react-window" "*"
+
+"@types/react-window@*":
+  version "1.8.5"
+  resolved "https://registry.yarnpkg.com/@types/react-window/-/react-window-1.8.5.tgz#285fcc5cea703eef78d90f499e1457e9b5c02fc1"
+  integrity sha512-V9q3CvhC9Jk9bWBOysPGaWy/Z0lxYcTXLtLipkt2cnRj1JOSFNF7wqGpkScSXMgBwC+fnVRg/7shwgddBG5ICw==
+  dependencies:
+    "@types/react" "*"
+
 "@types/react-window@^1.8.2":
   version "1.8.2"
   resolved "https://registry.yarnpkg.com/@types/react-window/-/react-window-1.8.2.tgz#a5a6b2762ce73ffaab7911ee1397cf645f2459fe"
@@ -5237,6 +5252,11 @@ eslint-plugin-prettier@^3.1.4:
   integrity sha512-Rq3jkcFY8RYeQLgk2cCwuc0P7SEFwDravPhsJZOQ5N4YI4DSg50NyqJ/9gdZHzQlHf8MvafSesbNJCcP/FF6pQ==
   dependencies:
     prettier-linter-helpers "^1.0.0"
+
+eslint-plugin-react-hooks@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.2.0.tgz#8c229c268d468956334c943bb45fc860280f5556"
+  integrity sha512-623WEiZJqxR7VdxFCKLI6d6LLpwJkGPYKODnkH3D7WpOG5KM8yWueBd8TLsNAetEJNF5iJmolaAKO3F8yzyVBQ==
 
 eslint-plugin-react@^7.18.3:
   version "7.22.0"
@@ -9433,6 +9453,11 @@ rc@^1.2.8:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
+react-cool-inview@^2.0.7:
+  version "2.0.7"
+  resolved "https://registry.yarnpkg.com/react-cool-inview/-/react-cool-inview-2.0.7.tgz#682d8c12bffe0484e1e7cf3fd5134f5eee711ad0"
+  integrity sha512-rwOZ+A4MhJSBqC/WyO6epUjTqhfXnkrnqolW3UklQohIenEdfHhHBvzfQ3o0WDihQOVx61YCD4iwnBUFFZ5guA==
+
 react-d3-graph@^2.5.0:
   version "2.6.0"
   resolved "https://registry.yarnpkg.com/react-d3-graph/-/react-d3-graph-2.6.0.tgz#b994131e430b568e086970560ba8a26809113173"
@@ -9508,6 +9533,11 @@ react-virtualized-auto-sizer@^1.0.2:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/react-virtualized-auto-sizer/-/react-virtualized-auto-sizer-1.0.4.tgz#2b83adb5ecdee8dcb33784e96ee0074eb5369665"
   integrity sha512-fdrY0ZX4Ywv0IIYPY/grQXcVQ44OLOsftl2u81coKe2Ga1wT3ps4JXaeu1JdlfjQxDI5BVsWjZQbpzmjmtI7Qw==
+
+react-window-infinite-loader@^1.0.7:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/react-window-infinite-loader/-/react-window-infinite-loader-1.0.7.tgz#958ef1a689d20dce122ef377583acd987760aee8"
+  integrity sha512-wg3LWkUpG21lhv+cZvNy+p0+vtclZw+9nP2vO6T9PKT50EN1cUq37Dq6FzcM38h/c2domE0gsUhb6jHXtGogAA==
 
 react-window@^1.8.6:
   version "1.8.6"


### PR DESCRIPTION
This PR adds a number of features necessary for implementing conda-store environment management in gator:

## Changes:
* Created React widgets for most of the conda-store frontend needs. These borrow styles heavily from the ones currently used for managing conda environments, but the implementations are quite different.
* Added `react-cool-inview` as dependency for making use of the Intersection Observer API
* The frontend now lists environments and conda-store packages. Both are lazily loaded from the conda-store server, fetching a page at a time as the user scrolls down. The packages panel contains both installed packages and available packages; if a package is installed, a version string is shown in the list.
* Added `rules-of-hooks` and `exhaustive-deps` eslint rules to help with react development
* Add `*.ipynb` to `.gitignore`
* Added `watch` script to run `lerna run watch --parallel`, for building/watching the frontend as we develop
* Fixed a bug where `NbConda` would appear to load indefinitely if there was an error loading environments
* Disable the bundle analyzer plugin which makes a `webpack-report.html` popup every time a change is detected in the frontend
* Temporarily allow unused locals in tsconfig, because the frontend is feature-incomplete. Will reenable before merging to Quantstack/gator
* Since I rebased on top of this branch anyway, I pulled in https://github.com/Quansight/gator/pull/26/commits/a46025b3d8f66eb406b6859576cbf54db15ca0ce

## Related issues
https://github.com/Quansight/conda-store/issues/133
https://github.com/Quansight/conda-store/issues/134